### PR TITLE
support non-pet-service-account users in bucket read/write user counts

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -14,3 +14,4 @@
 .gitignore
 
 node_modules
+README.md

--- a/index.js
+++ b/index.js
@@ -50,7 +50,13 @@ function getUserLookupTable(callback, event) {
         console.error(err);
         throw(err);
       } else {
-        userLookupTable = JSON.stringify(contents);
+        // the `contents` arg in this callback is a buffer containing the file contents.
+        // convert the buffer to a string and parse into an object.
+        // we expect the file contents to be reasonably sized so this is safe.
+        const theString = contents.toString('utf8')
+        const theData = JSON.parse(theString);
+        // console.log("found user lookups: " + JSON.stringify(theData));
+        userLookupTable = theData;
         return callback(event);  
       }
     })

--- a/index.js
+++ b/index.js
@@ -45,12 +45,15 @@ function getUserLookupTable(callback, event) {
   storage
     .bucket("secret-storage")
     .file("userLookups.json")
-    .createReadStream().then( (stream) => {
-      stream.json().then( obj => {
-        userLookupTable = obj;
-        return callback(event);
-      });
-    });
+    .download(function(err, contents) {
+      if (err != null) {
+        console.error(err);
+        throw(err);
+      } else {
+        userLookupTable = JSON.stringify(contents);
+        return callback(event);  
+      }
+    })
 }
 
 function shipLog(event) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getApiKey(callback, event) {
   // console.log("api key lookup in progress");
   storage
     .bucket("secret-storage")
-    .file("dev-logit.json")
+    .file("logit.json")
     .getMetadata()
     .then(results => {
       const metadata = results[0];
@@ -41,7 +41,7 @@ function getApiKey(callback, event) {
 }
 
 function getUserLookupTable(callback, event) {
-  console.log("user lookup table read in progress");
+  // console.log("user lookup table read in progress");
   storage
     .bucket("secret-storage")
     .file("userLookups.json")
@@ -91,6 +91,7 @@ function shipLog(event) {
         if (userLookupTable === null) {
           return getUserLookupTable(shipLog, event);
         } else {
+          // console.log("using cached user lookup table");
           if (userLookupTable.hasOwnProperty(principalEmail)) {
             manualLookup = true;
             subjectId = userLookupTable[principalEmail];

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,12 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+      "optional": true
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -326,6 +332,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-crc32c": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fast-crc32c/-/fast-crc32c-1.0.4.tgz",
+      "integrity": "sha1-qLVm6aouI7a0EWzz2NB/X1ItVOM=",
+      "requires": {
+        "sse4_crc32": "5.2.0"
+      }
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -654,6 +668,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "optional": true
+    },
     "node-forge": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
@@ -826,6 +846,16 @@
       "requires": {
         "async": "2.6.0",
         "is-stream-ended": "0.1.4"
+      }
+    },
+    "sse4_crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-5.2.0.tgz",
+      "integrity": "sha1-9lsZIQWx42doPKFCKgYU4dHaPBU=",
+      "optional": true,
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.8.0"
       }
     },
     "sshpk": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "@google-cloud/storage": "^1.6.0",
+    "@google-cloud/storage": "^1.7.0",
     "fast-crc32c": "^1.0.4",
-    "request": "^2.85.0",
+    "request": "^2.87.0",
     "request-promise-native": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
+    "fast-crc32c": "^1.0.4",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5"
   }


### PR DESCRIPTION
I have updated the tech doc at https://docs.google.com/document/d/1H5B1SD_qllPt_GMfyvObe7JvqPyJ0IO0aoAyG5yEcSQ/edit?usp=sharing with a diagram and some commentary on the implementation.

This PR adds the ability to track non-pet-service-account users. Highlights are:
* we store an email->subjectId json file in a protected GCS bucket
* json file is lazily read and stored in memory the first time it's needed
* when the cloud function encounters a non-pet-service-account, it looks up the subjectid in that mapping
* ugly: we'll need to maintain the mapping over time, maybe as a task every 1-2 weeks.

I don't like the manual maintenance very much, but I'd like to monitor it over the next month or two and see how many updates are actually needed before building out anything more sophisticated.

I've run this for ~24 hours against the prod pub/sub channel but streaming to the dev logit instance, and all looked good.